### PR TITLE
Specify extension key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,10 @@
 	"replace": {
 		"fab/vidi_frontend": "self.version",
 		"typo3-ter/vidi-frontend": "self.version"
+	},
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "vidi-frontend"
+		}
 	}
 }


### PR DESCRIPTION
Because this is a new requirement of TYPO3, as described in:

https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra