### PR TITLE
Compatibility with CLI mode

### DIFF
--- a/Classes/Configuration/TcaTweak.php
+++ b/Classes/Configuration/TcaTweak.php
@@ -7,6 +7,8 @@ namespace Fab\VidiFrontend\Configuration;
  * For the full copyright and license information, please read the
  * LICENSE.md file that was distributed with this source code.
  */
+
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\ApplicationType;
 use Fab\Vidi\Tca\TcaServiceInterface;
 
@@ -93,12 +95,11 @@ class TcaTweak
 
     /**
      * Returns whether the current mode is Frontend
-     *
-     * @return bool
      */
-    protected function isFrontendMode()
+    protected function isFrontendMode(): bool
     {
-        return ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend();
+        return ($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
+            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend();
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,16 @@
 	},
 	"require": {
 		"typo3/cms-core": "^11.0",
-		"fab/vidi": "^5 || dev-master"
+		"fab/vidi": "^5 || dev-master",
+		"typo3/cms-backend": "^11.0",
+		"typo3/cms-extbase": "^11.0",
+		"typo3/cms-frontend": "^11.0",
+		"fluidtypo3/vhs": "^6.1"
+	},
+	"config": {
+		"allow-plugins": {
+			"typo3/cms-composer-installers": true,
+			"typo3/class-alias-loader": true
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
 		"fab/vidi": "^5 || dev-master",
 		"typo3/cms-backend": "^11.0",
 		"typo3/cms-extbase": "^11.0",
-		"typo3/cms-frontend": "^11.0",
-		"fluidtypo3/vhs": "^6.1"
+		"typo3/cms-frontend": "^11.0"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
When in CLI mode `TYPO3_REQUEST` might not always exist. So we cannot
access it blindly. Instead, we use the pattern officially recommended
by `\TYPO3\CMS\Core\Http\ApplicationType`.

Without this patch, extensions such as `messenger` would crash when
sending emails.

Also see https://support.ecodev.ch/issues/9183

This is in direct relation with https://github.com/fabarea/vidi/pull/211 and should be merged together.
